### PR TITLE
Revise daily task inputs and Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,39 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // User profiles
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // Quest data
+    match /quests/{questId} {
+      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+      allow read, update, delete: if request.auth != null && resource.data.userId == request.auth.uid;
+    }
+
+    // Mind data
+    match /minds/{mindId} {
+      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+      allow read, update, delete: if request.auth != null && resource.data.userId == request.auth.uid;
+    }
+
+    // Daily check data
+    match /dailyChecks/{checkId} {
+      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+      allow read, update, delete: if request.auth != null && resource.data.userId == request.auth.uid;
+    }
+
+    // Ideals data (legacy)
+    match /ideals/{idealId} {
+      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+      allow read, update, delete: if request.auth != null && resource.data.userId == request.auth.uid;
+    }
+
+    // Daily visions data (legacy)
+    match /daily_visions/{visionId} {
+      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+      allow read, update, delete: if request.auth != null && resource.data.userId == request.auth.uid;
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -223,8 +223,12 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="dailyTasks">毎日やること（1行1タスク）</label>
-                        <textarea id="dailyTasks" rows="5" placeholder="例:&#10;腕立て伏せ20回&#10;腹筋30回&#10;ランニング5km"></textarea>
+                        <label for="dailyTaskInputs">毎日やること</label>
+                        <div id="dailyTaskInputs" class="daily-task-inputs"></div>
+                        <button type="button" class="add-daily-task-btn" onclick="addDailyTaskInput()">
+                            <span class="material-icons">add</span>
+                            タスクを追加
+                        </button>
                     </div>
 
                     <div class="form-group">

--- a/styles.css
+++ b/styles.css
@@ -973,8 +973,16 @@ body {
     align-items: center;
 }
 
-.kpi-input-group input {
+.kpi-input-group input,
+.daily-task-input-group input {
     flex: 1;
+    color: var(--text-primary);
+}
+
+.kpi-input-group input::placeholder,
+.daily-task-input-group input::placeholder {
+    color: var(--text-secondary);
+    opacity: 0.9;
 }
 
 .kpi-input-group .kpi-target {
@@ -985,7 +993,21 @@ body {
     max-width: 80px;
 }
 
-.remove-kpi-btn {
+.daily-task-inputs {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.daily-task-input-group {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.remove-kpi-btn,
+.remove-daily-task-btn {
     padding: 4px;
     background: transparent;
     border: none;
@@ -995,11 +1017,13 @@ body {
     transition: all 0.2s;
 }
 
-.remove-kpi-btn:hover {
+.remove-kpi-btn:hover,
+.remove-daily-task-btn:hover {
     background: rgba(239, 68, 68, 0.1);
 }
 
-.add-kpi-btn {
+.add-kpi-btn,
+.add-daily-task-btn {
     padding: 8px 16px;
     background: var(--bg-tertiary);
     border: 1px solid var(--border-color);
@@ -1014,10 +1038,15 @@ body {
     transition: all 0.2s;
 }
 
-.add-kpi-btn:hover {
+.add-kpi-btn:hover,
+.add-daily-task-btn:hover {
     background: var(--primary-light);
     color: white;
     border-color: var(--primary-light);
+}
+
+.add-daily-task-btn {
+    margin-top: 4px;
 }
 
 /* モーダルアクション */


### PR DESCRIPTION
## Summary
- add Firestore security rules for quests, minds, and daily check collections that enforce per-user access
- switch the quest modal's daily task field to dynamic per-line inputs with add/remove controls and wire them into the save flow
- adjust KPI and daily task input styling so labels and placeholders match the rest of the form

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cfc9fc1fec832c8a4828fc3b0f2ac6