### PR TITLE
Adjust KPI and daily task input colors

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -976,13 +976,13 @@ body {
 .kpi-input-group input,
 .daily-task-input-group input {
     flex: 1;
-    color: var(--text-primary);
+    color: #000000;
 }
 
 .kpi-input-group input::placeholder,
 .daily-task-input-group input::placeholder {
-    color: var(--text-secondary);
-    opacity: 0.9;
+    color: #000000;
+    opacity: 1;
 }
 
 .kpi-input-group .kpi-target {


### PR DESCRIPTION
## Summary
- change KPI and daily task input text and placeholder colors to pure black for better contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff125631c832c94f6f926ac7b65d1