### PR TITLE
Align placeholder colors across forms

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -959,6 +959,12 @@ body {
     line-height: 1.5;
 }
 
+input::placeholder,
+textarea::placeholder {
+    color: var(--text-muted);
+    opacity: 1;
+}
+
 /* KPI入力 */
 .kpi-inputs {
     display: flex;
@@ -981,7 +987,7 @@ body {
 
 .kpi-input-group input::placeholder,
 .daily-task-input-group input::placeholder {
-    color: #000000;
+    color: var(--text-muted);
     opacity: 1;
 }
 


### PR DESCRIPTION
## Summary
- unify placeholder styling for inputs and textareas by applying the shared muted text color
- update KPIおよび日次タスク入力のプレースホルダーも同じ色に揃えて視認性を統一

## Testing
- not run (static CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68cff4666adc832ca40fc00021213af3