### PR TITLE
Enable reordering and pinning for minds

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -722,6 +722,36 @@ body {
     gap: 16px;
 }
 
+.mind-item.dragging {
+    opacity: 0.7;
+}
+
+.mind-drag-handle {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: grab;
+    flex-shrink: 0;
+    border-radius: var(--border-radius-sm);
+    transition: color 0.2s, background 0.2s;
+}
+
+.mind-drag-handle:active {
+    cursor: grabbing;
+}
+
+.mind-drag-handle:hover,
+.mind-drag-handle:focus-visible {
+    background: var(--bg-tertiary);
+    color: var(--primary-color);
+    outline: none;
+}
+
 .mind-checkbox {
     flex: 1;
     display: flex;
@@ -761,12 +791,16 @@ body {
 
 .mind-content {
     flex: 1;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
 }
 
 .mind-text {
     font-size: 16px;
     color: var(--text-primary);
     line-height: 1.5;
+    flex: 1;
 }
 
 .mind-checkbox input[type="checkbox"]:checked ~ .mind-content .mind-text {
@@ -775,6 +809,7 @@ body {
 
 .mind-actions {
     display: flex;
+    align-items: center;
     gap: 4px;
     opacity: 0;
     transition: opacity 0.2s;
@@ -785,7 +820,8 @@ body {
 }
 
 .mind-edit-btn,
-.mind-delete-btn {
+.mind-delete-btn,
+.mind-pin-btn {
     padding: 4px;
     background: transparent;
     border: none;
@@ -800,9 +836,43 @@ body {
     color: var(--primary-color);
 }
 
+.mind-pin-btn:hover {
+    background: var(--bg-tertiary);
+    color: var(--warning-color);
+}
+
 .mind-delete-btn:hover {
     background: var(--bg-tertiary);
     color: var(--danger-color);
+}
+
+.mind-pin-btn .material-icons {
+    transform: rotate(-45deg);
+    transition: transform 0.2s, color 0.2s;
+}
+
+.mind-pin-btn.active .material-icons {
+    transform: rotate(0deg);
+    color: var(--warning-color);
+}
+
+.mind-pin-btn.active {
+    color: var(--warning-color);
+}
+
+.mind-pin-indicator {
+    color: var(--warning-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    line-height: 1;
+}
+
+@media (hover: none) {
+    .mind-actions {
+        opacity: 1;
+    }
 }
 
 .checked-minds-list .mind-item {


### PR DESCRIPTION
## Summary
- allow minds to be reordered via drag-and-drop and persist their order in Firestore
- add pin toggles for minds with visual indicators and persistence
- style the mind list with drag handles, pinned icons, and defaults for new entries

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0322ff644832c8c0db8199980885d