### PR TITLE
Fix quest note display to stay on one line

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -425,6 +425,9 @@ body {
     line-height: 1.5;
     padding-top: 12px;
     border-top: 1px solid var(--border-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 /* 完了セクション */


### PR DESCRIPTION
## Summary
- keep quest badge note text on a single line
- hide overflow and add ellipsis to prevent multi-line wrapping

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d148565f54832c94bf91a7d1feff20